### PR TITLE
Fixed: index.php inside the examples folder throwing error while accessing '/error' route.

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -106,7 +106,11 @@ $app->get("/", function ($c) {
 
 $app->get("/error", function ($c) {
     $customResponse = $c->html("<h1>Something went wrong</h1>", 404);
-    throw new HTTPException(404, "Something went wrong", $customResponse);
+    throw new HTTPException(
+        statusCode: 404,
+        message: "Something went wrong",
+        customResponse: $customResponse
+    );
 });
 
 $app->run();


### PR DESCRIPTION
Hey, I gotta solution 😃 for issue #24 .

Since we provided three arguments, PHP assumes that they correspond to the first three parameters in the constructor's signature. It doesn’t automatically skip to the fifth parameter, which is why the error occurs.

PHP determines which arguments correspond to which parameters based on their order. As we are using PHP 8.3 or later for Dumbo PHP, we can utilize named arguments to pass values directly to specific parameters, regardless of their order. Named arguments have support for PHP 8.0 or Later versions.

Thank you.