### PR TITLE
chore: use __DIR__ in require autoload

### DIFF
--- a/examples/basic-auth-custom/index.php
+++ b/examples/basic-auth-custom/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\BasicAuth;

--- a/examples/basic-auth-multiple-users/index.php
+++ b/examples/basic-auth-multiple-users/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\BasicAuth;

--- a/examples/basic-auth-nested/index.php
+++ b/examples/basic-auth-nested/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\BasicAuth;

--- a/examples/basic-auth/index.php
+++ b/examples/basic-auth/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\BasicAuth;

--- a/examples/bearer-auth-nested-route/index.php
+++ b/examples/bearer-auth-nested-route/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\BearerAuth;

--- a/examples/bearer-auth/index.php
+++ b/examples/bearer-auth/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\BearerAuth;

--- a/examples/body-limit/index.php
+++ b/examples/body-limit/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\BodyLimit;

--- a/examples/compress/index.php
+++ b/examples/compress/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\Compress;

--- a/examples/context-variables/index.php
+++ b/examples/context-variables/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 

--- a/examples/cookies/index.php
+++ b/examples/cookies/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\Cookie;

--- a/examples/cors/index.php
+++ b/examples/cors/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\CORS;

--- a/examples/html/index.php
+++ b/examples/html/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 

--- a/examples/json/index.php
+++ b/examples/json/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 

--- a/examples/logger/index.php
+++ b/examples/logger/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\Logger;
@@ -43,7 +43,7 @@ $user->get("/:id", function ($c) use ($userData) {
     $id = (int) $c->req->param("id");
 
     $user =
-        array_values(array_filter($userData, fn($u) => $u["id"] === $id))[0] ??
+        array_values(array_filter($userData, fn ($u) => $u["id"] === $id))[0] ??
         null;
 
     if (!$user) {

--- a/examples/middleware/index.php
+++ b/examples/middleware/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 

--- a/examples/redirect/index.php
+++ b/examples/redirect/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 

--- a/examples/request-id/index.php
+++ b/examples/request-id/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\Helpers\RequestId;

--- a/examples/route-params/index.php
+++ b/examples/route-params/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 

--- a/examples/simple/index.php
+++ b/examples/simple/index.php
@@ -1,9 +1,10 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 use Dumbo\HTTPException;
+
 // use Dumbo\Helpers\BearerAuth;
 
 $app = new Dumbo();
@@ -30,7 +31,7 @@ $user->get("/:id", function ($c) use ($userData) {
     $id = (int) $c->req->param("id");
 
     $user =
-        array_values(array_filter($userData, fn($u) => $u["id"] === $id))[0] ??
+        array_values(array_filter($userData, fn ($u) => $u["id"] === $id))[0] ??
         null;
 
     if (!$user) {
@@ -58,7 +59,7 @@ $user->delete("/:id", function ($c) use ($userData) {
     $id = (int) $c->req->param("id");
 
     $user =
-        array_values(array_filter($userData, fn($u) => $u["id"] === $id))[0] ??
+        array_values(array_filter($userData, fn ($u) => $u["id"] === $id))[0] ??
         null;
 
     if (!$user) {

--- a/examples/text/index.php
+++ b/examples/text/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
 

--- a/examples/turso-http/index.php
+++ b/examples/turso-http/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Darkterminal\TursoHttp\LibSQL;
 use Dumbo\Dumbo;


### PR DESCRIPTION
It seems like good practice to use` __DIR__` to get the absolute directory we're in.