### PR TITLE
CSRF Protection middleware

### DIFF
--- a/examples/cookie-auth/index.php
+++ b/examples/cookie-auth/index.php
@@ -153,7 +153,7 @@ $app->get("/", function ($c) use ($latte) {
 });
 
 $app->get("/register", function ($c) use ($latte) {
-    $csrfToken = Cookie::getCookie($c, "csrf_token");
+    $csrfToken = $c->get("csrf_token");
     $html = render($latte, "register", [
         "csrf_token" => $csrfToken,
     ]);
@@ -190,7 +190,7 @@ $app->post("/register", function ($c) use ($db, $latte) {
 
 $app->get("/login", function ($c) use ($latte) {
     $flashMessage = $c->get("flash_message");
-    $csrfToken = Cookie::getCookie($c, "csrf_token");
+    $csrfToken = $c->get("csrf_token");
     $html = render($latte, "login", [
         "flash_message" => $flashMessage,
         "csrf_token" => $csrfToken,
@@ -310,8 +310,7 @@ $app->get("/settings", function ($c) use ($db, $latte) {
         return $c->redirect("/login");
     }
 
-    $csrfToken = Cookie::getCookie($c, "csrf_token");
-
+    $csrfToken = $c->get("csrf_token");
     $sessions = $db
         ->query(
             "SELECT id, user_agent, ip_address, expires_at FROM sessions WHERE user_id = ? AND expires_at > ?",

--- a/examples/cookie-auth/index.php
+++ b/examples/cookie-auth/index.php
@@ -62,18 +62,20 @@ $app->onError(function ($error, $c) {
     );
 });
 
-$app->use(CsrfMiddleware::csrf([
-    'getToken' => function ($ctx) {
-        return Cookie::getCookie($ctx, 'csrf_token') ?? null;
-    },
-    'setToken' => function ($ctx, $token) {
-        Cookie::setCookie($ctx, 'csrf_token', $token, [
-            'httpOnly' => true,
-            'secure' => true,
-            'sameSite' => 'Lax',
-        ]);
-    },
-]));
+$app->use(
+    CsrfMiddleware::csrf([
+        "getToken" => function ($ctx) {
+            return Cookie::getCookie($ctx, "csrf_token") ?? null;
+        },
+        "setToken" => function ($ctx, $token) {
+            Cookie::setCookie($ctx, "csrf_token", $token, [
+                "httpOnly" => true,
+                "secure" => true,
+                "sameSite" => "Lax",
+            ]);
+        },
+    ])
+);
 
 $app->use(function ($c, $next) use ($db) {
     $sessionId = Cookie::getSignedCookie(
@@ -85,7 +87,7 @@ $app->use(function ($c, $next) use ($db) {
     $debugSessionId = $_COOKIE["debug_session"] ?? "Not set";
     error_log(
         "Middleware: Session ID from cookie: " .
-        ($sessionId ? $sessionId : "Not set")
+            ($sessionId ? $sessionId : "Not set")
     );
     error_log("Middleware: Debug Session ID: " . $debugSessionId);
 
@@ -108,7 +110,7 @@ $app->use(function ($c, $next) use ($db) {
             if (!empty($user)) {
                 error_log(
                     "Middleware: User found for session: " .
-                    $user[0]["username"]
+                        $user[0]["username"]
                 );
                 $c->set("user", $user[0]);
             } else {
@@ -133,28 +135,27 @@ $app->get("/", function ($c) use ($latte) {
     $flashMessage = $c->get("flash_message");
     error_log(
         "Home route: User " .
-        ($user
-            ? "is logged in as " . $user["username"]
-            : "is not logged in")
+            ($user
+                ? "is logged in as " . $user["username"]
+                : "is not logged in")
     );
     error_log(
         "Home route: Flash message: " .
-        ($flashMessage ? $flashMessage : "No flash message")
+            ($flashMessage ? $flashMessage : "No flash message")
     );
 
     $html = render($latte, "home", [
         "user" => $user,
         "flash_message" => $flashMessage,
     ]);
-    $c->set("flash_message", null); // Clear the flash message after displaying
+    $c->set("flash_message", null);
     return $c->html($html);
 });
 
 $app->get("/register", function ($c) use ($latte) {
-    $csrfToken = Cookie::getCookie($c, 'csrf_token');
+    $csrfToken = Cookie::getCookie($c, "csrf_token");
     $html = render($latte, "register", [
         "csrf_token" => $csrfToken,
-
     ]);
     return $c->html($html);
 });
@@ -189,7 +190,7 @@ $app->post("/register", function ($c) use ($db, $latte) {
 
 $app->get("/login", function ($c) use ($latte) {
     $flashMessage = $c->get("flash_message");
-    $csrfToken = Cookie::getCookie($c, 'csrf_token');
+    $csrfToken = Cookie::getCookie($c, "csrf_token");
     $html = render($latte, "login", [
         "flash_message" => $flashMessage,
         "csrf_token" => $csrfToken,
@@ -256,9 +257,9 @@ $app->post("/login", function ($c) use ($db, $latte) {
 
             error_log(
                 "Session cookie set: " .
-                SESSION_COOKIE_NAME .
-                " = " .
-                $sessionId
+                    SESSION_COOKIE_NAME .
+                    " = " .
+                    $sessionId
             );
 
             $c->set("flash_message", "Login successful.");
@@ -309,6 +310,8 @@ $app->get("/settings", function ($c) use ($db, $latte) {
         return $c->redirect("/login");
     }
 
+    $csrfToken = Cookie::getCookie($c, "csrf_token");
+
     $sessions = $db
         ->query(
             "SELECT id, user_agent, ip_address, expires_at FROM sessions WHERE user_id = ? AND expires_at > ?",
@@ -319,6 +322,7 @@ $app->get("/settings", function ($c) use ($db, $latte) {
     $html = render($latte, "settings", [
         "user" => $user,
         "sessions" => $sessions,
+        "csrf_token" => $csrfToken,
     ]);
 
     return $c->html($html);

--- a/examples/cookie-auth/views/login.latte
+++ b/examples/cookie-auth/views/login.latte
@@ -16,6 +16,7 @@
             <input type="password" id="password" name="password" required>
         </div>
         <button type="submit">Login</button>
+        <input type="hidden" name="csrf_token" value="{$csrf_token}">
     </form>
     <p>Don't have an account? <a href="/register">Register</a></p>
     <p><a href="/">Back to Home</a></p>

--- a/examples/cookie-auth/views/login.latte
+++ b/examples/cookie-auth/views/login.latte
@@ -6,7 +6,7 @@
         <p style="color: red;">{$error}</p>
     {/if}
     <form action="/login" method="post">
-        <input type="hidden" name="csrf_token" value="{$csrfToken}">
+        <input type="hidden" name="csrf_token" value="{$csrf_token}">
         <div>
             <label for="username">Username:</label>
             <input type="text" id="username" name="username" required>

--- a/examples/cookie-auth/views/register.latte
+++ b/examples/cookie-auth/views/register.latte
@@ -16,6 +16,7 @@
             <input type="password" id="password" name="password" required>
         </div>
         <button type="submit">Register</button>
+        <input type="hidden" name="csrf_token" value="{$csrf_token}">
     </form>
     <p>Already have an account? <a href="/login">Login</a></p>
     <p><a href="/">Back to Home</a></p>

--- a/examples/cookie-auth/views/register.latte
+++ b/examples/cookie-auth/views/register.latte
@@ -6,7 +6,7 @@
         <p style="color: red;">{$error}</p>
     {/if}
     <form action="/register" method="post">
-        <input type="hidden" name="csrf_token" value="{$csrfToken}">
+        <input type="hidden" name="csrf_token" value="{$csrf_token}">
         <div>
             <label for="username">Username:</label>
             <input type="text" id="username" name="username" required>

--- a/examples/cookie-auth/views/settings.latte
+++ b/examples/cookie-auth/views/settings.latte
@@ -9,7 +9,7 @@
         <p style="color: green;">{$success}</p>
     {/if}
     <form action="/settings" method="post">
-        <input type="hidden" name="csrf_token" value="{$csrfToken}">
+        <input type="hidden" name="csrf_token" value="{$csrf_token}">
         <div>
             <label for="username">New Username:</label>
             <input type="text" id="username" name="username" value="{$user['username']}">
@@ -41,8 +41,7 @@
                 <td>{date('Y-m-d H:i:s', $session['expires_at'])}</td>
                 <td>
                      <form action="/invalidate-session" method="post">
-                            <input type="hidden" name="csrf_token" value="{$csrfToken}">
-                        <input type="hidden" name="csrf_token" value="{$csrfToken}">
+                        <input type="hidden" name="csrf_token" value="{$csrf_token}">
                         <input type="hidden" name="session_id" value="{$session['id']}">
                         <button type="submit">Invalidate</button>
                     </form>

--- a/src/Middleware/CsrfMiddleware.php
+++ b/src/Middleware/CsrfMiddleware.php
@@ -89,6 +89,10 @@ class CsrfMiddleware
             $ctx->header($options['headerName'], $token);
         }
 
+        if ($ctx->get($options['tokenName']) === null) {
+            $ctx->set($options['tokenName'], $token);
+        }
+
         return $next($ctx);
     }
 

--- a/src/Middleware/CsrfMiddleware.php
+++ b/src/Middleware/CsrfMiddleware.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Dumbo\Middleware;
+
+use Closure;
+use Dumbo\Context;
+
+class CsrfMiddleware
+{
+    const SAFE_METHODS = [
+        'GET',
+        'HEAD',
+        'OPTIONS',
+        'TRACE'
+    ];
+
+    const FORM_CONTENT_TYPES = [
+        'application/x-www-form-urlencoded',
+        'multipart/form-data',
+        'text/plain'
+    ];
+
+    public static function csrf(array $options = []): Closure
+    {
+        return function (Context $ctx, callable $next) use ($options) {
+            $method = $ctx->req->method();
+            $contentType = $ctx->req->header('Content-Type');
+            $origin = $ctx->req->header('Origin');
+
+            if (self::isSafeMethod($method)) {
+                return $next($ctx);
+            }
+
+            if (self::isFormRequest($contentType) && !self::isAllowedOrigin($origin, $ctx, $options)) {
+                return $ctx->text('Forbidden ', 403);
+            }
+
+            return $next($ctx);
+        };
+    }
+
+    private static function isSafeMethod(?string $method): bool
+    {
+        return !($method == null) && in_array(strtoupper($method), self::SAFE_METHODS);
+    }
+
+    private static function isFormRequest(string $contentType): bool
+    {
+        return in_array($contentType, self::FORM_CONTENT_TYPES);
+    }
+
+    private static function isAllowedOrigin(?string $origin, Context $ctx, array $options): bool
+    {
+        if ($origin === null) {
+            return false;
+        }
+
+        if (!isset($options['origin'])) {
+            return $origin === self::getRequestOrigin($ctx);
+        }
+
+        $allowedOrigins = $options['origin'];
+
+        if (is_string($allowedOrigins)) {
+            return $origin === $allowedOrigins;
+        }
+
+        if (is_array($allowedOrigins)) {
+            return in_array($origin, $allowedOrigins);
+        }
+
+        if (is_callable($allowedOrigins)) {
+            return $allowedOrigins($origin, $ctx);
+        }
+
+        return false;
+    }
+
+    private static function getRequestOrigin(Context $ctx): string
+    {
+        $url = $ctx->req->routePath();
+        $parsedUrl = parse_url($url);
+        dd( $parsedUrl['scheme'] . '://' . $parsedUrl['host']);
+        return $parsedUrl['scheme'] . '://' . $parsedUrl['host'];
+    }
+
+}

--- a/tests/CsrfMiddlewareTest.php
+++ b/tests/CsrfMiddlewareTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Dumbo\Tests;
+
+use Dumbo\Context;
+use Dumbo\Middleware\CsrfMiddleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+class CsrfMiddlewareTest extends TestCase
+{
+    private function createMockContext($method = 'GET', $headers = [], $path = '/'): Context
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getMethod')->willReturn($method);
+
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('getPath')->willReturn($path);
+        $request->method('getUri')->willReturn($uri);
+
+        $request->method('getHeader')
+            ->willReturnCallback(function ($headerName) use ($headers) {
+                return $headers[$headerName] ?? [];
+            });
+
+        $request->method('getHeaders')->willReturn($headers);
+
+        return new Context($request, [], $path);
+    }
+
+    public function testAllowsSafeMethodsWithoutOrigin()
+    {
+        $middleware = CsrfMiddleware::csrf();
+        $context = $this->createMockContext();
+
+        $next = function ($ctx) {
+            return new Response(200, [], 'Response body');
+        };
+
+        $response = $middleware($context, $next);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testBlocksUnsafeMethodWithoutOrigin()
+    {
+        $middleware = CsrfMiddleware::csrf();
+        $context = $this->createMockContext('POST', ['Content-Type' => ['application/x-www-form-urlencoded']]);
+
+        $next = function ($ctx) {
+            return new Response(200, [], 'Response body');
+        };
+
+        $response = $middleware($context, $next);
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function testAllowsUnsafeMethodWithCorrectOrigin()
+    {
+        $middleware = CsrfMiddleware::csrf(['origin' => 'https://example.com']);
+        $context = $this->createMockContext('POST', [
+            'Content-Type' => ['application/x-www-form-urlencoded'],
+            'Origin' => ['https://example.com']
+        ]);
+
+        $next = function ($ctx) {
+            return new Response(200, [], 'Response body');
+        };
+
+        $response = $middleware($context, $next);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testBlocksUnsafeMethodWithIncorrectOrigin()
+    {
+        $middleware = CsrfMiddleware::csrf(['origin' => 'https://example.com']);
+        $context = $this->createMockContext('POST', [
+            'Content-Type' => ['application/x-www-form-urlencoded'],
+            'Origin' => ['https://malicious.com']
+        ]);
+
+        $next = function ($ctx) {
+            return new Response(200, [], 'Response body');
+        };
+
+        $response = $middleware($context, $next);
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function testAllowsUnsafeMethodWithCorrectOriginInArray()
+    {
+        $middleware = CsrfMiddleware::csrf(['origin' => ['https://example.com', 'https://subdomain.example.com']]);
+        $context = $this->createMockContext('POST', [
+            'Content-Type' => ['application/x-www-form-urlencoded'],
+            'Origin' => ['https://subdomain.example.com']
+        ]);
+
+        $next = function ($ctx) {
+            return new Response(200, [], 'Response body');
+        };
+
+        $response = $middleware($context, $next);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testAllowsUnsafeMethodWithCustomOriginFunction()
+    {
+        $middleware = CsrfMiddleware::csrf([
+            'origin' => function($origin) {
+                return str_contains($origin, '.example.com');
+            }
+        ]);
+        $context = $this->createMockContext('POST', [
+            'Content-Type' => ['application/x-www-form-urlencoded'],
+            'Origin' => ['https://custom.example.com']
+        ]);
+
+        $next = function ($ctx) {
+            return new Response(200, [], 'Response body');
+        };
+
+        $response = $middleware($context, $next);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testIgnoresNonFormRequests()
+    {
+        $middleware = CsrfMiddleware::csrf();
+        $context = $this->createMockContext('POST', ['Content-Type' => ['application/json']]);
+
+        $next = function ($ctx) {
+            return new Response(200, [], 'Response body');
+        };
+
+        $response = $middleware($context, $next);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/CsrfMiddlewareTest.php
+++ b/tests/CsrfMiddlewareTest.php
@@ -85,8 +85,6 @@ class CsrfMiddlewareTest extends TestCase
 
     public function testUnsafeMethodWithInvalidToken()
     {
-        $this->tokenStorage['csrf_token'] = bin2hex(random_bytes(32));
-
         $middleware = CsrfMiddleware::csrf([
             'getToken' => $this->getTokenCallback(),
             'setToken' => $this->setTokenCallback(),
@@ -105,8 +103,6 @@ class CsrfMiddlewareTest extends TestCase
 
     public function testUnsafeMethodWithMissingToken()
     {
-        $this->tokenStorage['csrf_token'] = bin2hex(random_bytes(32));
-
         $middleware = CsrfMiddleware::csrf([
             'getToken' => $this->getTokenCallback(),
             'setToken' => $this->setTokenCallback(),
@@ -125,8 +121,6 @@ class CsrfMiddlewareTest extends TestCase
 
     public function testCustomErrorHandler()
     {
-        $this->tokenStorage['csrf_token'] = bin2hex(random_bytes(32));
-
         $middleware = CsrfMiddleware::csrf([
             'getToken' => $this->getTokenCallback(),
             'setToken' => $this->setTokenCallback(),


### PR DESCRIPTION
I feel that the current implementation of CSRF middleware does not provide sufficient protection against CSRF attacks 😅

This code relies heavily on the `Origin` header: an attacker can easily forge this header, bypassing our protection

After some research, it seems that the best way to implement CSRF protection is to use a token-based verification system with either : 
1. A token stored in a cookie
2. A token that will be stored in the X-CSRF header that will be returned with each request.

What do you think ? 

Closes #50 