### PR TITLE
refactor: rename helpers to middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ composer.lock
 .idea
 .fleet
 .vscode
+.devcontainer
 cache
 file.db
 .phpunit.result.cache

--- a/examples/basic-auth-custom/index.php
+++ b/examples/basic-auth-custom/index.php
@@ -3,12 +3,12 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\BasicAuth;
+use Dumbo\Middleware\BasicAuthMiddleware;
 
 $app = new Dumbo();
 
 $app->use(
-    BasicAuth::basicAuth([
+    BasicAuthMiddleware::basicAuth([
         "verifyUser" => function ($username, $password, $context) {
             // You could call a database here...
             $validUsers = [

--- a/examples/basic-auth-multiple-users/index.php
+++ b/examples/basic-auth-multiple-users/index.php
@@ -3,12 +3,12 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\BasicAuth;
+use Dumbo\Middleware\BasicAuthMiddleware;
 
 $app = new Dumbo();
 
 $app->use(
-    BasicAuth::basicAuth([
+    BasicAuthMiddleware::basicAuth([
         "users" => [
             ["username" => "user1", "password" => "pass1"],
             ["username" => "user2", "password" => "pass2"],

--- a/examples/basic-auth-nested/index.php
+++ b/examples/basic-auth-nested/index.php
@@ -3,12 +3,12 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\BasicAuth;
+use Dumbo\Middleware\BasicAuthMiddleware;
 
 $app = new Dumbo();
 $api = new Dumbo();
 
-$api->use(BasicAuth::basicAuth("user:password"));
+$api->use(BasicAuthMiddleware::basicAuth("user:password"));
 
 $api->get("/", function ($context) {
     return $context->html("<h1>Welcome to the protected area!</h1>");

--- a/examples/basic-auth/index.php
+++ b/examples/basic-auth/index.php
@@ -3,11 +3,11 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\BasicAuth;
+use Dumbo\Middleware\BasicAuthMiddleware;
 
 $app = new Dumbo();
 
-$app->use(BasicAuth::basicAuth("user:password"));
+$app->use(BasicAuthMiddleware::basicAuth("user:password"));
 
 $app->get("/", function ($context) {
     return $context->html("<h1>Welcome to the protected area!</h1>");

--- a/examples/bearer-auth-nested-route/index.php
+++ b/examples/bearer-auth-nested-route/index.php
@@ -3,14 +3,14 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\BearerAuth;
+use Dumbo\Middleware\BearerAuthMiddleware;
 
 $app = new Dumbo();
 $api = new Dumbo();
 
 $token = "mysupersecret";
 
-$api->use(BearerAuth::bearerAuth($token));
+$api->use(BearerAuthMiddleware::bearerAuth($token));
 
 $api->get("/", function ($context) {
     return $context->json([

--- a/examples/bearer-auth/index.php
+++ b/examples/bearer-auth/index.php
@@ -3,12 +3,12 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\BearerAuth;
+use Dumbo\Middleware\BearerAuthMiddleware;
 
 $app = new Dumbo();
 $token = "mysupersecret";
 
-$app->use(BearerAuth::bearerAuth($token));
+$app->use(BearerAuthMiddleware::bearerAuth($token));
 
 $app->get("/", function ($context) {
     return $context->json([

--- a/examples/body-limit/index.php
+++ b/examples/body-limit/index.php
@@ -3,15 +3,15 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\BodyLimit;
+use Dumbo\Middleware\BodyLimitMiddleware;
 
 $app = new Dumbo();
 
 // Limit the body size to 1MB
-$app->use(BodyLimit::limit(1024 * 1024));
+$app->use(BodyLimitMiddleware::limit(1024 * 1024));
 
 // Or apply it with custom response
-// $app->use(BodyLimit::limit(1024 * 1024, function($context) {
+// $app->use(BodyLimitMiddleware::limit(1024 * 1024, function($context) {
 //     return $context->json(['error' => 'Body too large'], 413);
 // }));
 

--- a/examples/compress/index.php
+++ b/examples/compress/index.php
@@ -3,12 +3,12 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\Compress;
+use Dumbo\Middleware\CompressMiddleware;
 
 $app = new Dumbo();
 
 $app->use(
-    Compress::compress([
+    CompressMiddleware::compress([
         "threshold" => 1024, // Minimum size to compress (bytes)
         "encoding" => "gzip", // Preferred encoding (gzip or deflate)
     ])

--- a/examples/logger/index.php
+++ b/examples/logger/index.php
@@ -3,7 +3,7 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\Logger;
+use Dumbo\Middleware\LoggerMiddleware;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Logger as MonologLogger;
 use Monolog\Handler\StreamHandler;
@@ -19,7 +19,7 @@ $formatter = new LineFormatter(
 $handler->setFormatter($formatter);
 $logger->pushHandler($handler);
 
-$app->use(Logger::logger($logger));
+$app->use(LoggerMiddleware::logger($logger));
 
 $app->get("/", function ($context) {
     return $context->html("<h1>We've just logged something on the console!</h1>");

--- a/examples/request-id/index.php
+++ b/examples/request-id/index.php
@@ -3,15 +3,15 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\RequestId;
+use Dumbo\Middleware\RequestIdMiddleware;
 
 $app = new Dumbo();
 
-$app->use(RequestId::requestId());
+$app->use(RequestIdMiddleware::requestId());
 
 // Or apply it with custom options
 // $app->use(
-//     RequestId::requestId([
+//     RequestIdMiddleware::requestId([
 //         "headerName" => "X-Custom-Request-Id",
 //         "limitLength" => 128,
 //         "generator" => function ($context) {

--- a/examples/static-assets/index.php
+++ b/examples/static-assets/index.php
@@ -3,11 +3,11 @@
 require __DIR__ . "/vendor/autoload.php";
 
 use Dumbo\Dumbo;
-use Dumbo\Helpers\StaticFiles;
+use Dumbo\Middleware\StaticFilesMiddleware;
 
 $app = new Dumbo();
 
-$app->use("/", StaticFiles::serve(__DIR__ . "/assets"));
+$app->use("/", StaticFilesMiddleware::serve(__DIR__ . "/assets"));
 
 // $app->get("/", StaticFiles::serve(__DIR__ . "/assets"));
 

--- a/src/Context.php
+++ b/src/Context.php
@@ -3,7 +3,6 @@
 namespace Dumbo;
 
 use Closure;
-use Dumbo\Helpers\View;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Helpers/StaticFiles.php
+++ b/src/Helpers/StaticFiles.php
@@ -3,7 +3,6 @@
 namespace Dumbo\Helpers;
 
 use Dumbo\Context;
-use Psr\Http\Message\ResponseInterface;
 
 class StaticFiles
 {

--- a/src/Middleware/BasicAuthMiddleware.php
+++ b/src/Middleware/BasicAuthMiddleware.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Dumbo\Helpers;
+namespace Dumbo\Middleware;
 
 use Dumbo\Context;
 use Psr\Http\Message\ResponseInterface;
 
-class BasicAuth
+class BasicAuthMiddleware
 {
     private const STATUS_UNAUTHORIZED = 401;
     private const HEADER_AUTHORIZATION = "Authorization";

--- a/src/Middleware/BearerAuthMiddleware.php
+++ b/src/Middleware/BearerAuthMiddleware.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Dumbo\Helpers;
+namespace Dumbo\Middleware;
 
 use Dumbo\Context;
 use Psr\Http\Message\ResponseInterface;
 
-class BearerAuth
+class BearerAuthMiddleware
 {
     private const STATUS_UNAUTHORIZED = 401;
     private const HEADER_AUTHORIZATION = "Authorization";

--- a/src/Middleware/BodyLimitMiddleware.php
+++ b/src/Middleware/BodyLimitMiddleware.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Dumbo\Helpers;
+namespace Dumbo\Middleware;
 
 use Dumbo\Context;
 use Dumbo\HTTPException;
 use Psr\Http\Message\ResponseInterface;
 
-class BodyLimit
+class BodyLimitMiddleware
 {
     /**
      * Create a middleware that limits the size of the request body

--- a/src/Middleware/CompressMiddleware.php
+++ b/src/Middleware/CompressMiddleware.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Dumbo\Helpers;
+namespace Dumbo\Middleware;
 
 use Dumbo\Context;
 use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
-class Compress
+class CompressMiddleware
 {
     private const STR_REGEX = '/^\s*(?:text\/[^;\s]+|application\/(?:javascript|json|xml|xml-dtd|ecmascript|dart|postscript|rtf|tar|toml|vnd\.dart|vnd\.ms-fontobject|vnd\.ms-opentype|wasm|x-httpd-php|x-javascript|x-ns-proxy-autoconfig|x-sh|x-tar|x-virtualbox-hdd|x-virtualbox-ova|x-virtualbox-ovf|x-virtualbox-vbox|x-virtualbox-vdi|x-virtualbox-vhd|x-virtualbox-vmdk|x-www-form-urlencoded)|font\/(?:otf|ttf)|image\/(?:bmp|vnd\.adobe\.photoshop|vnd\.microsoft\.icon|vnd\.ms-dds|x-icon|x-ms-bmp)|message\/rfc822|model\/gltf-binary|x-shader\/x-fragment|x-shader\/x-vertex|[^;\s]+?\+(?:json|text|xml|yaml))(?:[;\s]|$)/i';
 

--- a/src/Middleware/CsrfMiddleware.php
+++ b/src/Middleware/CsrfMiddleware.php
@@ -7,7 +7,6 @@ use Dumbo\Context;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 
-
 class CsrfMiddleware
 {
     private const SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS', 'TRACE'];

--- a/src/Middleware/LoggerMiddleware.php
+++ b/src/Middleware/LoggerMiddleware.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Dumbo\Helpers;
+namespace Dumbo\Middleware;
 
 use Dumbo\Context;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
-class Logger
+class LoggerMiddleware
 {
     public const LOG_PREFIX_INCOMING = "-->";
     public const LOG_PREFIX_OUTGOING = "<--";

--- a/src/Middleware/RequestIdMiddleware.php
+++ b/src/Middleware/RequestIdMiddleware.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Dumbo\Helpers;
+namespace Dumbo\Middleware;
 
 use Dumbo\Context;
 use Psr\Http\Message\ResponseInterface;
 
-class RequestId
+class RequestIdMiddleware
 {
     private const DEFAULT_HEADER_NAME = "X-Request-Id";
     private const DEFAULT_LIMIT_LENGTH = 255;

--- a/src/Middleware/StaticFilesMiddleware.php
+++ b/src/Middleware/StaticFilesMiddleware.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Dumbo\Helpers;
+namespace Dumbo\Middleware;
 
 use Dumbo\Context;
 
-class StaticFiles
+class StaticFilesMiddleware
 {
     /**
      * Create a handler for serving static files

--- a/tests/Helpers/JWTTest.php
+++ b/tests/Helpers/JWTTest.php
@@ -3,8 +3,8 @@
 namespace Dumbo\Tests\Helpers;
 
 use Dumbo\Helpers\JWT;
+use Exception;
 use PHPUnit\Framework\TestCase;
-use Firebase\JWT\ExpiredException;
 
 class JWTTest extends TestCase
 {
@@ -35,7 +35,7 @@ class JWTTest extends TestCase
 
         $token = JWT::sign($payload, self::SECRET, self::ALG);
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage("Expired token");
         JWT::verify($token, self::SECRET, self::ALG);
     }
@@ -46,7 +46,7 @@ class JWTTest extends TestCase
 
         $token = JWT::sign($payload, self::SECRET, self::ALG);
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage("Invalid token");
         JWT::verify($token, "wrong_secret", self::ALG);
     }
@@ -74,7 +74,7 @@ class JWTTest extends TestCase
 
     public function testInvalidTokenFormat()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage("Invalid token format");
         JWT::decode("invalid.token");
     }

--- a/tests/Middleware/BasicAuthMiddlewareTest.php
+++ b/tests/Middleware/BasicAuthMiddlewareTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Dumbo\Tests\Helpers;
+namespace Dumbo\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
-use Dumbo\Helpers\BasicAuth;
+use Dumbo\Middleware\BasicAuthMiddleware;
 use Dumbo\Context;
 use Psr\Http\Message\ServerRequestInterface;
 use GuzzleHttp\Psr7\Response;
 
-class BasicAuthTest extends TestCase
+class BasicAuthMiddlewareTest extends TestCase
 {
     private function createMockContext($authHeader = null): Context
     {
@@ -23,7 +23,7 @@ class BasicAuthTest extends TestCase
 
     public function testSimpleBasicAuthSuccess()
     {
-        $middleware = BasicAuth::basicAuth("user:password");
+        $middleware = BasicAuthMiddleware::basicAuth("user:password");
         $context = $this->createMockContext(
             "Basic " . base64_encode("user:password")
         );
@@ -42,7 +42,7 @@ class BasicAuthTest extends TestCase
 
     public function testSimpleBasicAuthFailure()
     {
-        $middleware = BasicAuth::basicAuth("user:password");
+        $middleware = BasicAuthMiddleware::basicAuth("user:password");
         $context = $this->createMockContext(
             "Basic " . base64_encode("wrong:credentials")
         );
@@ -62,7 +62,7 @@ class BasicAuthTest extends TestCase
 
     public function testAdvancedBasicAuthWithUsersSuccess()
     {
-        $middleware = BasicAuth::basicAuth([
+        $middleware = BasicAuthMiddleware::basicAuth([
             "users" => [
                 ["username" => "alice", "password" => "pass123"],
                 ["username" => "bob", "password" => "secret"],
@@ -86,7 +86,7 @@ class BasicAuthTest extends TestCase
 
     public function testAdvancedBasicAuthWithVerifyUserSuccess()
     {
-        $middleware = BasicAuth::basicAuth([
+        $middleware = BasicAuthMiddleware::basicAuth([
             "verifyUser" => function ($username, $password) {
                 return $username === "admin" && $password === "secret";
             },
@@ -109,7 +109,7 @@ class BasicAuthTest extends TestCase
 
     public function testAdvancedBasicAuthFailure()
     {
-        $middleware = BasicAuth::basicAuth([
+        $middleware = BasicAuthMiddleware::basicAuth([
             "users" => [["username" => "alice", "password" => "pass123"]],
         ]);
         $context = $this->createMockContext(

--- a/tests/Middleware/BearerAuthMiddlewareTest.php
+++ b/tests/Middleware/BearerAuthMiddlewareTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Dumbo\Tests\Helpers;
+namespace Dumbo\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
-use Dumbo\Helpers\BearerAuth;
+use Dumbo\Middleware\BearerAuthMiddleware;
 use Dumbo\Context;
 use Psr\Http\Message\ServerRequestInterface;
 use GuzzleHttp\Psr7\Response;
 
-class BearerAuthTest extends TestCase
+class BearerAuthMiddlewareTest extends TestCase
 {
     private function createMockContext($authHeader = null): Context
     {
@@ -23,7 +23,7 @@ class BearerAuthTest extends TestCase
 
     public function testSimpleBearerAuthSuccess()
     {
-        $middleware = BearerAuth::bearerAuth("valid-token");
+        $middleware = BearerAuthMiddleware::bearerAuth("valid-token");
         $context = $this->createMockContext("Bearer valid-token");
 
         $called = false;
@@ -40,7 +40,7 @@ class BearerAuthTest extends TestCase
 
     public function testSimpleBearerAuthFailure()
     {
-        $middleware = BearerAuth::bearerAuth("valid-token");
+        $middleware = BearerAuthMiddleware::bearerAuth("valid-token");
         $context = $this->createMockContext("Bearer invalid-token");
 
         $next = function ($context) {
@@ -58,7 +58,7 @@ class BearerAuthTest extends TestCase
 
     public function testAdvancedBearerAuthWithTokensSuccess()
     {
-        $middleware = BearerAuth::bearerAuth([
+        $middleware = BearerAuthMiddleware::bearerAuth([
             "tokens" => ["token1", "token2"],
         ]);
         $context = $this->createMockContext("Bearer token2");
@@ -77,7 +77,7 @@ class BearerAuthTest extends TestCase
 
     public function testAdvancedBearerAuthWithVerifyTokenSuccess()
     {
-        $middleware = BearerAuth::bearerAuth([
+        $middleware = BearerAuthMiddleware::bearerAuth([
             "verifyToken" => function ($token) {
                 return $token === "valid-token";
             },
@@ -98,7 +98,7 @@ class BearerAuthTest extends TestCase
 
     public function testAdvancedBearerAuthFailure()
     {
-        $middleware = BearerAuth::bearerAuth([
+        $middleware = BearerAuthMiddleware::bearerAuth([
             "tokens" => ["token1", "token2"],
         ]);
         $context = $this->createMockContext("Bearer invalid-token");
@@ -118,7 +118,7 @@ class BearerAuthTest extends TestCase
 
     public function testMissingAuthorizationHeader()
     {
-        $middleware = BearerAuth::bearerAuth("valid-token");
+        $middleware = BearerAuthMiddleware::bearerAuth("valid-token");
         $context = $this->createMockContext();
 
         $next = function ($context) {
@@ -136,7 +136,7 @@ class BearerAuthTest extends TestCase
 
     public function testInvalidAuthorizationHeaderFormat()
     {
-        $middleware = BearerAuth::bearerAuth("valid-token");
+        $middleware = BearerAuthMiddleware::bearerAuth("valid-token");
         $context = $this->createMockContext("InvalidFormat token");
 
         $next = function ($context) {
@@ -154,7 +154,7 @@ class BearerAuthTest extends TestCase
 
     public function testCustomRealm()
     {
-        $middleware = BearerAuth::bearerAuth([
+        $middleware = BearerAuthMiddleware::bearerAuth([
             "tokens" => ["valid-token"],
             "realm" => "Custom Realm",
         ]);

--- a/tests/Middleware/CacheMiddlewareTest.php
+++ b/tests/Middleware/CacheMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dumbo\Tests;
+namespace Dumbo\Tests\Middleware;
 
 use Dumbo\Context;
 use Dumbo\Middleware\CacheMiddleware;

--- a/tests/Middleware/CsrfMiddlewareTest.php
+++ b/tests/Middleware/CsrfMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dumbo\Tests;
+namespace Dumbo\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Dumbo\Context;

--- a/tests/Middleware/LoggerMiddlewareTest.php
+++ b/tests/Middleware/LoggerMiddlewareTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Dumbo\Tests\Helpers;
+namespace Dumbo\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Http\Message\ResponseInterface;
-use Dumbo\Helpers\Logger;
+use Dumbo\Middleware\LoggerMiddleware;
 use Dumbo\Context;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 
-class LoggerTest extends TestCase
+class LoggerMiddlewareTest extends TestCase
 {
     private function createMockContext(string $method, string $path): Context
     {
@@ -27,9 +27,9 @@ class LoggerTest extends TestCase
     public function testLoggerInstance()
     {
         $loggerMock = $this->createMock(LoggerInterface::class);
-        $middleware = Logger::logger($loggerMock);
+        $middleware = LoggerMiddleware::logger($loggerMock);
 
-        $this->assertInstanceOf(Logger::class, $middleware);
+        $this->assertInstanceOf(LoggerMiddleware::class, $middleware);
     }
 
     public function testInvokeLogsIncomingAndOutgoingRequest()
@@ -48,7 +48,7 @@ class LoggerTest extends TestCase
         $responseMock = $this->createMock(ResponseInterface::class);
         $responseMock->method('getStatusCode')->willReturn(200);
 
-        $middleware = Logger::logger($loggerMock);
+        $middleware = LoggerMiddleware::logger($loggerMock);
 
         $next = fn () => $responseMock;
 
@@ -56,10 +56,10 @@ class LoggerTest extends TestCase
 
         $this->assertCount(2, $messages);
 
-        $this->assertStringContainsString(Logger::LOG_PREFIX_INCOMING, $messages[0]);
+        $this->assertStringContainsString(LoggerMiddleware::LOG_PREFIX_INCOMING, $messages[0]);
         $this->assertStringContainsString('GET /test-path', $messages[0]);
 
-        $this->assertStringContainsString(Logger::LOG_PREFIX_OUTGOING, $messages[1]);
+        $this->assertStringContainsString(LoggerMiddleware::LOG_PREFIX_OUTGOING, $messages[1]);
         $this->assertStringContainsString('GET /test-path', $messages[1]);
         $this->assertStringContainsString('200', $messages[1]);
     }

--- a/tests/Middleware/RequestIdMiddlewareTest.php
+++ b/tests/Middleware/RequestIdMiddlewareTest.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace Dumbo\Tests\Helpers;
+namespace Dumbo\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Dumbo\Dumbo;
-use Dumbo\Helpers\RequestId;
+use Dumbo\Middleware\RequestIdMiddleware;
 use GuzzleHttp\Psr7\ServerRequest;
 
-class RequestIdTest extends TestCase
+class RequestIdMiddlewareTest extends TestCase
 {
     public function testRequestIdMiddleware()
     {
         $app = new Dumbo();
 
         $app->use(
-            RequestId::requestId([
+            RequestIdMiddleware::requestId([
                 "headerName" => "X-Custom-Request-Id",
                 "limitLength" => 128,
                 "generator" => function ($context) {
@@ -48,7 +48,7 @@ class RequestIdTest extends TestCase
         $app = new Dumbo();
 
         $app->use(
-            RequestId::requestId([
+            RequestIdMiddleware::requestId([
                 "headerName" => "X-Custom-Request-Id",
             ])
         );


### PR DESCRIPTION
This PR renames the following helpers to the `CacheMiddleware` style


- `BasicAuth`
- `BearerAuth`
- `BodyLimit`
- `CORS`
- `Compress`
- `RequestId`
- `Logger`
- `StaticFiles`

closes https://github.com/notrab/dumbo/issues/49

